### PR TITLE
automake: symlink README.md to README

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
This fixes following error:

```
Makefile.am: error: required file './README' not found
autoreconf: automake failed with exit status: 1
autogen.sh failed
```

Fixes: 536f5aaa0912 ("Delete README")
Closes: #4
Signed-off-by: You-Sheng Yang <vicamo@gmail.com>