### PR TITLE
Fix invalid volatile type for glibc 2.35

### DIFF
--- a/src/gstcambasesrc.cpp
+++ b/src/gstcambasesrc.cpp
@@ -246,7 +246,7 @@ static gboolean gst_cam_base_src_send_video_stream_start (GstCamBaseSrc *src, Gs
 GType
 gst_cam_base_src_get_type (void)
 {
-  static volatile gsize cam_base_src_type = 0;
+  static gsize cam_base_src_type = 0;
 
   if (g_once_init_enter(&cam_base_src_type)) {
     GType _type;

--- a/src/gstcamerasrcbufferpool.cpp
+++ b/src/gstcamerasrcbufferpool.cpp
@@ -79,7 +79,7 @@ GType
 gst_camerasrc_meta_api_get_type (void)
 {
   PERF_CAMERA_ATRACE();
-  static volatile GType type;
+  static GType type;
   static const gchar *tags[] = { "memory", NULL };
 
   if (g_once_init_enter (&type)) {


### PR DESCRIPTION
Fixes: #10